### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "lodash": "^4.17.11",
     "memoize-one": "5.0.0",
     "normalizr": "3.3.0",
-    "npm": "6.4.1",
     "react": "^16.8.6",
     "react-native": "^0.59.9",
     "react-native-add-calendar-event": "^2.2.0",


### PR DESCRIPTION

Hello edouarobin!

It seems like you have npm as one of your (dev-) dependency in intramuros-demo.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
